### PR TITLE
Fix: prevent divide-by-zero crash when no categories are selected

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -69,6 +69,13 @@ namespace Quick_Disk_Cleanup_Helper
             int totalSteps = (clearTemp ? 1 : 0) + (clearRecycle ? 1 : 0) + (clearCache ? 1 : 0) + (clearLog ? 1 : 0) + (clearWinUpdCache ? 1 : 0);
             int currentStep = 0;
 
+            if (totalSteps == 0)
+            {
+                MessageBox.Show("Select at least one cleanup category.");
+                cleanupButton.IsEnabled = true;
+                return;
+            }
+
             long totalFreedBytes = 0;
 
             try


### PR DESCRIPTION
This PR fixes a potential divide-by-zero crash in the cleanup workflow.
When no categories are selected, `totalSteps` becomes 0, which causes a crash when updating the progress bar.

This patch adds a guard clause to check if `totalSteps == 0` and exits early with a user message.

Closes #7
